### PR TITLE
fix(docs): fix release-please pattern and restore version badge format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # crashpad-rs
 
-<!-- x-release-please-start-version -->
-![Version](https://img.shields.io/badge/version-0.2.4)
-<!-- x-release-please-end -->
+![Version](https://img.shields.io/badge/version-0.2.4-blue.svg)
 [![docs.rs](https://docs.rs/crashpad-rs/badge.svg)](https://docs.rs/crashpad-rs)
 [![crates.io](https://img.shields.io/crates/d/crashpad-rs.svg)](https://crates.io/crates/crashpad-rs)
 [![Build Status](https://github.com/bahamoth/crashpad-rs/actions/workflows/test-android.yml/badge.svg)](https://github.com/bahamoth/crashpad-rs/actions/workflows/test-android.yml)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,8 +25,8 @@
           "glob": "README.md",
           "updateLine": [
             {
-              "pattern": "badge/version-([0-9]+\\.[0-9]+\\.[0-9]+)",
-              "replacement": "badge/version-${version}"
+              "pattern": "badge/version-([0-9]+\\.[0-9]+\\.[0-9]+)-blue\\.svg",
+              "replacement": "badge/version-${version}-blue.svg"
             },
             {
               "pattern": "crashpad-rs = \"([0-9]+\\.[0-9]+\\.[0-9]+)\"",


### PR DESCRIPTION
- Update release-please pattern to preserve full badge URL with -blue.svg suffix
- Restore version badge format after v0.2.4 bump
- Pattern now correctly matches and preserves the complete badge format